### PR TITLE
Unify CLI rule specification options with rule file options

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -408,7 +408,7 @@ The following flags are available:
 ifndef::without-systemd[]
 *systemd*[='FD_NAME']::
   Enable systemd socket activation
-  (see <<rule-opt-socket-activation,*socketActivation*>> below), optionally
+  (see <<rule-opt-socket-activation,*systemd*>> below), optionally
   specifying a file descriptior name (<<rule-opt-fdname,*fdName*>>).
 endif::[]
 
@@ -491,7 +491,7 @@ Placeholders are allowed here and those are substituted accordingly:
 *%%*;; verbatim `%`
 
 ifndef::without-systemd[]
-[[rule-opt-socket-activation]]*socketActivation*::
+[[rule-opt-socket-activation]]*systemd*::
 ifndef::manmanual[]
 If *ip2unix* is compiled with systemd support, whether to use socket activation
 endif::[]
@@ -600,7 +600,7 @@ ifndef::without-systemd[]
 - direction: incoming                 ## <6>
   type: tcp
   port: 22
-  socketActivation: true
+  systemd: true
   fdName: ssh
 endif::without-systemd[]
 --------------------------------------------

--- a/README.adoc
+++ b/README.adoc
@@ -82,7 +82,7 @@ Executes a program and converts IP to Unix domain sockets at runtime based on a
 list of rules, either given via short command line options (see {rulespec}) or
 via a file with a list of rules (see {rulefileformat}). The first matching rule
 causes *ip2unix* to replace the current IP socket with a Unix domain socket
-based on the options given. For example if a <<rule-socket-path,*socketPath*>>
+based on the options given. For example if a <<rule-socket-path,*path*>>
 is specified, the Unix domain socket will bind or listen to the given path.
 
 ifndef::manmanual[]
@@ -438,7 +438,7 @@ These options are available:
 
 *path*='SOCKET_PATH'::
   The path to the socket file to either bind or connect to, which is similar to
-  the <<rule-socket-path,*socketPath*>> rule file option but also allows
+  the <<rule-socket-path,*path*>> rule file option but also allows
   relative paths.
 
 == Rule file format
@@ -477,7 +477,7 @@ Optionally specifies the end of a port range to match, so for example if
 <<rule-opt-port,*port*>> is `2000` and *portEnd* is `3000` all ports in the
 range from 2000 to 3000 (inclusive) are matched.
 
-[[rule-socket-path]]*socketPath*::
+[[rule-socket-path]]*path*::
 
 The path to the socket file to use for either binding or connecting to
 depending on whether the above options apply for a particular IP socket.
@@ -498,7 +498,7 @@ endif::[]
 ifdef::manmanual[]
 Whether to use systemd socket activation
 endif::[]
-instead of a <<rule-socket-path,*socketPath*>>. See {systemd_socket}.
+instead of a <<rule-socket-path,*path*>>. See {systemd_socket}.
 
 [[rule-opt-fdname]]*fdName*::
 An optional file descriptor name for socket activation which can be used to
@@ -534,7 +534,7 @@ On the server side with the rule file `rules-server.yaml`:
 [source,yaml]
 ---------------------------------------------------------------------
 - direction: incoming
-  socketPath: /tmp/test.socket
+  path: /tmp/test.socket
 ---------------------------------------------------------------------
 
 The following command spawns a small test web server listening on
@@ -557,7 +557,7 @@ On the client side with `rules-client.yaml`:
 [source,yaml]
 ---------------------------------------------------------------------
 - direction: outgoing
-  socketPath: /tmp/test.socket
+  path: /tmp/test.socket
 ---------------------------------------------------------------------
 
 This connects to the test server listening on `/tmp/test.socket`
@@ -584,10 +584,10 @@ $ ip2unix -r out,path=/tmp/test.socket curl http://1.2.3.4/
   ignore: true
 - direction: outgoing                 ## <2>
   type: tcp
-  socketPath: /run/some.socket
+  path: /run/some.socket
 - direction: incoming                 ## <3>
   address: 1.2.3.4
-  socketPath: /run/another.socket
+  path: /run/another.socket
 - direction: incoming                 ## <4>
   port: 80
   address: abcd::1

--- a/src/rules/parse.cc
+++ b/src/rules/parse.cc
@@ -152,6 +152,11 @@ static std::optional<int> parse_errno(const std::string &str)
         return std::nullopt; \
     }
 
+#define DEPRECATED_RENAMED(option, alternative) \
+    RULE_ERROR("The \"" option "\" option is deprecated and has been" \
+               " renamed to \"" alternative "\". It will be removed in" \
+               " the next major version of ip2unix.")
+
 static std::optional<Rule> parse_rule(const std::string &file, int pos,
                                       const YAML::Node &doc)
 {
@@ -228,7 +233,11 @@ static std::optional<Rule> parse_rule(const std::string &file, int pos,
             RULE_CONVERT(rule.blackhole, "blackhole", bool, "bool");
         } else if (key == "ignore") {
             RULE_CONVERT(rule.ignore, "ignore", bool, "bool");
+        } else if (key == "path") {
+            RULE_CONVERT(rule.socket_path, "path", std::string,
+                         "string");
         } else if (key == "socketPath") {
+            DEPRECATED_RENAMED("socketPath", "path");
             RULE_CONVERT(rule.socket_path, "socketPath", std::string,
                          "string");
         } else {

--- a/src/rules/parse.cc
+++ b/src/rules/parse.cc
@@ -211,7 +211,11 @@ static std::optional<Rule> parse_rule(const std::string &file, int pos,
                 return std::nullopt;
             }
 #ifdef SYSTEMD_SUPPORT
+        } else if (key == "systemd") {
+            RULE_CONVERT(rule.socket_activation, "systemd", bool,
+                         "bool");
         } else if (key == "socketActivation") {
+            DEPRECATED_RENAMED("socketActivation", "systemd");
             RULE_CONVERT(rule.socket_activation, "socketActivation", bool,
                          "bool");
         } else if (key == "fdName") {

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -57,7 +57,7 @@ class TcpConnectionTest(unittest.TestCase):
     def assert_connection(self, crule, srule, cargs, sargs, pre_cmd_srv=None):
         client_rule = {'direction': 'outgoing', 'path': self.sockpath}
         client_rule.update(crule)
-        if 'socketActivation' in srule:
+        if 'systemd' in srule:
             sync = False
             server_rule = dict(srule)
         else:
@@ -105,7 +105,7 @@ class TcpConnectionTest(unittest.TestCase):
 
     @helper.systemd_sa_helper_only
     def test_socket_activation(self):
-        srule = {'socketActivation': True}
+        srule = {'systemd': True}
         args = ['-c', 10, '4.3.2.1', 321]
         pre_cmd = [helper.SYSTEMD_SA_PATH, '-l', self.sockpath]
         if self.SOTYPE == 'udp':
@@ -114,7 +114,7 @@ class TcpConnectionTest(unittest.TestCase):
 
     @helper.systemd_sa_helper_only
     def test_socket_activation_threaded(self):
-        srule = {'socketActivation': True}
+        srule = {'systemd': True}
         args = ['-m', 'threading', '-p', 10, '-c', 20, '4.3.2.1', 321]
         pre_cmd = [helper.SYSTEMD_SA_PATH, '-l', self.sockpath]
         if self.SOTYPE == 'udp':
@@ -123,7 +123,7 @@ class TcpConnectionTest(unittest.TestCase):
 
     @helper.systemd_sa_helper_only
     def test_socket_activation_with_fdname(self):
-        srule = {'socketActivation': True, 'fdName': 'foo', 'port': 333}
+        srule = {'systemd': True, 'fdName': 'foo', 'port': 333}
         args = ['-c', 10, '4.3.2.1', 333]
         extrasock = os.path.join(self.tmpdir, 'extra.sock')
         pre_cmd = [helper.SYSTEMD_SA_PATH, '-l', extrasock]

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -55,14 +55,14 @@ class TcpConnectionTest(unittest.TestCase):
             proc.stdin.write(b'\n')
 
     def assert_connection(self, crule, srule, cargs, sargs, pre_cmd_srv=None):
-        client_rule = {'direction': 'outgoing', 'socketPath': self.sockpath}
+        client_rule = {'direction': 'outgoing', 'path': self.sockpath}
         client_rule.update(crule)
         if 'socketActivation' in srule:
             sync = False
             server_rule = dict(srule)
         else:
             sync = True
-            server_rule = {'socketPath': self.sockpath}
+            server_rule = {'path': self.sockpath}
             server_rule.update(srule)
         with self.run_server([server_rule], *sargs, pre_cmd=pre_cmd_srv,
                              sync=sync):
@@ -93,9 +93,9 @@ class TcpConnectionTest(unittest.TestCase):
 
     def test_path_placeholders(self):
         args = ['127.0.0.1', 111]
-        srule = {'socketPath': os.path.join(self.tmpdir, '%a-%t-%p.sock')}
+        srule = {'path': os.path.join(self.tmpdir, '%a-%t-%p.sock')}
         clipath = '127.0.0.1-' + self.SOTYPE + '-111.sock'
-        crule = {'socketPath': os.path.join(self.tmpdir, clipath)}
+        crule = {'path': os.path.join(self.tmpdir, clipath)}
         self.assert_connection(crule, srule, args, args)
 
     def test_nomatch(self):

--- a/tests/test_fdleak.py
+++ b/tests/test_fdleak.py
@@ -23,7 +23,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
 @pytest.mark.skipif(not os.path.exists('/proc/self/fd'),
                     reason='requires procfs')
 def test_fdleak():
-    rules = [{'socketPath': '/dev/null/not/existing', 'direction': 'outgoing'}]
+    rules = [{'path': '/dev/null/not/existing', 'direction': 'outgoing'}]
     cmd = [sys.executable, '-c', TESTPROG]
     with helper.ip2unix(rules, cmd, stdout=subprocess.PIPE) as proc:
         stdout = proc.communicate()[0]

--- a/tests/test_program_args.py
+++ b/tests/test_program_args.py
@@ -36,7 +36,7 @@ def test_rulefile_and_ruledata():
 
 def test_rule_longopts(tmpdir):
     rulesfile = str(tmpdir.join('rules.yml'))
-    rulesdata = json.dumps([{'socketPath': '/test'}])
+    rulesdata = json.dumps([{'path': '/test'}])
     open(rulesfile, 'w').write(rulesdata)
     for cmd in [
         [IP2UNIX, '-cp', '--rules-file', rulesfile],

--- a/tests/test_rule_file.py
+++ b/tests/test_rule_file.py
@@ -20,7 +20,7 @@ class RuleFileTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0, msg)
 
     def test_no_array(self):
-        self.assert_bad_rules({'rule1': {'socketPath': '/foo'}})
+        self.assert_bad_rules({'rule1': {'path': '/foo'}})
         self.assert_bad_rules({'rule2': {}})
         self.assert_bad_rules({})
 
@@ -31,10 +31,10 @@ class RuleFileTest(unittest.TestCase):
         self.assert_good_rules([
             {'direction': 'outgoing',
              'type': 'udp',
-             'socketPath': '/tmp/foo'},
+             'path': '/tmp/foo'},
             {'direction': 'incoming',
              'address': '::',
-             'socketPath': '/tmp/bar'}
+             'path': '/tmp/bar'}
         ])
 
     def test_unknown_rule_attrs(self):
@@ -42,48 +42,47 @@ class RuleFileTest(unittest.TestCase):
         self.assert_bad_rules([{'socketpath': 'xxx'}])
 
     def test_wrong_rule_types(self):
-        self.assert_bad_rules([{'type': 'nope', 'socketPath': '/tmp/foo'}])
-        self.assert_bad_rules([{'direction': 'out', 'socketPath': '/tmp/foo'}])
-        self.assert_bad_rules([{'socketPath': 1234}])
+        self.assert_bad_rules([{'type': 'nope', 'path': '/tmp/foo'}])
+        self.assert_bad_rules([{'direction': 'out', 'path': '/tmp/foo'}])
+        self.assert_bad_rules([{'path': 1234}])
 
     def test_no_socket_path(self):
         self.assert_bad_rules([{'address': '1.2.3.4'}])
 
     def test_relative_socket_path(self):
-        self.assert_bad_rules([{'socketPath': 'aaa/bbb'}])
-        self.assert_bad_rules([{'socketPath': 'bbb'}])
+        self.assert_bad_rules([{'path': 'aaa/bbb'}])
+        self.assert_bad_rules([{'path': 'bbb'}])
 
     def test_absolute_socket_path(self):
-        self.assert_good_rules([{'socketPath': '/xxx'}])
+        self.assert_good_rules([{'path': '/xxx'}])
 
     def test_invalid_enums(self):
-        self.assert_bad_rules([{'socketPath': '/bbb', 'direction': 111}])
-        self.assert_bad_rules([{'socketPath': '/bbb', 'direction': False}])
-        self.assert_bad_rules([{'socketPath': '/bbb', 'type': 234}])
-        self.assert_bad_rules([{'socketPath': '/bbb', 'type': True}])
+        self.assert_bad_rules([{'path': '/bbb', 'direction': 111}])
+        self.assert_bad_rules([{'path': '/bbb', 'direction': False}])
+        self.assert_bad_rules([{'path': '/bbb', 'type': 234}])
+        self.assert_bad_rules([{'path': '/bbb', 'type': True}])
 
     def test_invalid_port_type(self):
-        self.assert_bad_rules([{'socketPath': '/aaa', 'port': 'foo'}])
-        self.assert_bad_rules([{'socketPath': '/aaa', 'port': True}])
-        self.assert_bad_rules([{'socketPath': '/aaa', 'port': -1}])
-        self.assert_bad_rules([{'socketPath': '/aaa', 'port': 65536}])
+        self.assert_bad_rules([{'path': '/aaa', 'port': 'foo'}])
+        self.assert_bad_rules([{'path': '/aaa', 'port': True}])
+        self.assert_bad_rules([{'path': '/aaa', 'port': -1}])
+        self.assert_bad_rules([{'path': '/aaa', 'port': 65536}])
 
     def test_port_range(self):
-        self.assert_good_rules([{'socketPath': '/aaa', 'port': 123,
-                                 'portEnd': 124}])
-        self.assert_good_rules([{'socketPath': '/aaa', 'port': 1000,
+        self.assert_good_rules([{'path': '/aaa', 'port': 123, 'portEnd': 124}])
+        self.assert_good_rules([{'path': '/aaa', 'port': 1000,
                                  'portEnd': 65535}])
 
     def test_invalid_port_range(self):
-        self.assert_bad_rules([{'socketPath': '/aaa', 'port': 123,
+        self.assert_bad_rules([{'path': '/aaa', 'port': 123,
                                 'portEnd': 10}])
-        self.assert_bad_rules([{'socketPath': '/aaa', 'port': 123,
+        self.assert_bad_rules([{'path': '/aaa', 'port': 123,
                                 'portEnd': 123}])
-        self.assert_bad_rules([{'socketPath': '/aaa', 'port': 123,
+        self.assert_bad_rules([{'path': '/aaa', 'port': 123,
                                 'portEnd': 65536}])
 
     def test_missing_start_port_in_range(self):
-        self.assert_bad_rules([{'socketPath': '/aaa', 'portEnd': 123}])
+        self.assert_bad_rules([{'path': '/aaa', 'portEnd': 123}])
 
     def test_valid_address(self):
         valid_addrs = [
@@ -92,7 +91,7 @@ class RuleFileTest(unittest.TestCase):
             '7::', '::2:1', '::17', 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff'
         ]
         for addr in valid_addrs:
-            self.assert_good_rules([{'socketPath': '/foo', 'address': addr}])
+            self.assert_good_rules([{'path': '/foo', 'address': addr}])
 
     def test_invalid_addrss(self):
         invalid_addrs = [
@@ -101,7 +100,7 @@ class RuleFileTest(unittest.TestCase):
             '8:7:6:5:4:3:2:1::', '::8:7:6:5:4:3:2:1', 'f:f11::01100:2'
         ]
         for addr in invalid_addrs:
-            self.assert_bad_rules([{'socketPath': '/foo', 'address': addr}])
+            self.assert_bad_rules([{'path': '/foo', 'address': addr}])
 
     def test_valid_reject(self):
         for val in ["EBADF", "EINTR", "enomem", "EnOMeM", 13, 12]:
@@ -112,7 +111,7 @@ class RuleFileTest(unittest.TestCase):
             self.assert_bad_rules([{'reject': True, 'rejectError': val}])
 
     def test_reject_with_sockpath(self):
-        self.assert_bad_rules([{'socketPath': '/foo', 'reject': True}])
+        self.assert_bad_rules([{'path': '/foo', 'reject': True}])
 
     def test_blackhole_with_reject(self):
         self.assert_bad_rules([{'direction': 'incoming', 'reject': True,
@@ -123,14 +122,14 @@ class RuleFileTest(unittest.TestCase):
         self.assert_bad_rules([{'direction': 'outgoing', 'blackhole': True}])
 
     def test_blackhole_with_sockpath(self):
-        self.assert_bad_rules([{'direction': 'incoming', 'socketPath': '/foo',
+        self.assert_bad_rules([{'direction': 'incoming', 'path': '/foo',
                                 'blackhole': True}])
 
     def test_blackhole_all(self):
         self.assert_good_rules([{'direction': 'incoming', 'blackhole': True}])
 
     def test_ignore_with_sockpath(self):
-        self.assert_bad_rules([{'socketPath': '/foo', 'ignore': True}])
+        self.assert_bad_rules([{'path': '/foo', 'ignore': True}])
 
     def test_ignore_with_reject(self):
         self.assert_bad_rules([{'reject': True, 'ignore': True}])
@@ -144,8 +143,7 @@ class RuleFileTest(unittest.TestCase):
 
     @systemd_only
     def test_contradicting_systemd(self):
-        self.assert_bad_rules([{'socketPath': '/foo',
-                                'socketActivation': True}])
+        self.assert_bad_rules([{'path': '/foo', 'socketActivation': True}])
 
     @systemd_only
     def test_socket_fdname(self):
@@ -160,9 +158,9 @@ class RuleFileTest(unittest.TestCase):
         rules = [
             {'direction': 'outgoing',
              'type': 'tcp',
-             'socketPath': '/foo'},
+             'path': '/foo'},
             {'address': '0.0.0.0',
-             'socketPath': '/bar'}
+             'path': '/bar'}
         ]
         cmd = [IP2UNIX, '-cp', '-F', json.dumps(rules)]
         result = subprocess.run(cmd, stderr=subprocess.PIPE,
@@ -174,7 +172,7 @@ class RuleFileTest(unittest.TestCase):
         self.assertIn(b'IP Type', result.stdout)
 
     def test_print_rules_stderr(self):
-        rules = [{'socketPath': '/xxx'}]
+        rules = [{'path': '/xxx'}]
         cmd = [IP2UNIX, '-p', '-F', json.dumps(rules),
                sys.executable, '-c', '']
         result = subprocess.run(cmd, stderr=subprocess.PIPE,
@@ -184,3 +182,19 @@ class RuleFileTest(unittest.TestCase):
         self.assertNotEqual(result.stderr, b'')
         self.assertGreater(len(result.stderr), 0)
         self.assertIn(b'IP Type', result.stderr)
+
+    def assert_deprecated_rule(self, rules, rule_name, new_name):
+        cmd = [IP2UNIX, '-c', '-F', json.dumps(rules)]
+        result = subprocess.run(cmd, capture_output=True)
+        expected = '<unknown>:rule #1: The "{}" option is deprecated and' \
+                   ' has been renamed to "{}". It will be removed in the' \
+                   ' next major version of ip2unix.\n'
+        expected_stderr = expected.format(rule_name, new_name).encode()
+        self.assertEqual(result.stderr, expected_stderr)
+        self.assertEqual(result.stdout, b'')
+        msg = "Deprecated options should not fail the validation"
+        self.assertEqual(result.returncode, 0, msg)
+
+    def test_deprecated(self):
+        rules = [{'socketPath': '/xxx'}]
+        self.assert_deprecated_rule(rules, 'socketPath', 'path')

--- a/tests/test_rule_file.py
+++ b/tests/test_rule_file.py
@@ -143,16 +143,16 @@ class RuleFileTest(unittest.TestCase):
 
     @systemd_only
     def test_contradicting_systemd(self):
-        self.assert_bad_rules([{'path': '/foo', 'socketActivation': True}])
+        self.assert_bad_rules([{'path': '/foo', 'systemd': True}])
 
     @systemd_only
     def test_socket_fdname(self):
-        self.assert_good_rules([{'socketActivation': True, 'fdName': 'foo'}])
+        self.assert_good_rules([{'systemd': True, 'fdName': 'foo'}])
 
     @non_systemd_only
     def test_no_systemd_options(self):
-        self.assert_bad_rules([{'socketActivation': True}])
-        self.assert_bad_rules([{'socketActivation': True, 'fdName': 'foo'}])
+        self.assert_bad_rules([{'systemd': True}])
+        self.assert_bad_rules([{'systemd': True, 'fdName': 'foo'}])
 
     def test_print_rules_check_stdout(self):
         rules = [
@@ -198,3 +198,8 @@ class RuleFileTest(unittest.TestCase):
     def test_deprecated(self):
         rules = [{'socketPath': '/xxx'}]
         self.assert_deprecated_rule(rules, 'socketPath', 'path')
+
+    @systemd_only
+    def test_deprecated_systemd(self):
+        rules = [{'socketActivation': True}]
+        self.assert_deprecated_rule(rules, 'socketActivation', 'systemd')

--- a/tests/test_run_direct.py
+++ b/tests/test_run_direct.py
@@ -18,7 +18,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
 
 def test_run_direct(tmpdir):
     sockfile = tmpdir.join('foo.sock')
-    rules = [{'direction': 'outgoing', 'socketPath': str(sockfile)}]
+    rules = [{'direction': 'outgoing', 'path': str(sockfile)}]
     rulefile = tmpdir.join('rules.json')
     rulefile.write(json.dumps(rules))
     cmd = [sys.executable, '-c', TESTPROG]

--- a/tests/test_sockopt_fail.py
+++ b/tests/test_sockopt_fail.py
@@ -19,7 +19,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
 
 
 def test_setsockopt_fail(tmpdir):
-    rules = [{'socketPath': str(tmpdir.join('foo.sock'))}]
+    rules = [{'path': str(tmpdir.join('foo.sock'))}]
     cmd = [sys.executable, '-c', TESTPROG]
     with helper.ip2unix(rules, cmd) as proc:
         assert proc.wait() == 0


### PR DESCRIPTION
Since the rule file was implemented first, the option names are still unchanged to date, but when introducing the [`-r` command line option](https://github.com/nixcloud/ip2unix/tree/54d96bba2ac9bd5a22e881409fca83e115acecdc#2-rule-specification), I decided to go for short names instead.

This however is a bit confusing if you're used to `-r` and suddenly have to use different option names for the rule files.

Some options however are a bit difficult to unify, because they have different semantics:

  * The `portEnd` rule file option doesn't exist as an extra option in the CLI specification, but needs to be specified in a range notation, like eg. `port=200-300`.
  * Likewise, the `fdName` option is simply `systemd=some_fd_name`, but it might be a good idea to nest the option, resulting in `systemd.enable` and `systemd.fdName`.
  * The `reject` option also has three states in the CLI specification: `disabled`, `enabled` and `enabled with errno`.

I'm not quite sure what would be the best way to handle this yet, because if we'd use nested attributes, the `port` option would still be different because it's not simply a boolean with an optional string/integer value. When translating the `port` CLI option into a nested object, it would look like this for two different rules:

```yaml
- path: foo
  port:
    start: 30
    end: 80
- path: bar
  port:
    exact: 443
```

This clearly makes the port option much more confusing than simply having a `port` option along with an optional `portEnd` option.

Another way to approach this is to allow different types for those options, for example the `systemd` option would then either accept a boolean or a string. I'd consider this the ugliest option and it also won't work so well with the port option, except if we'd parse it in the same way as in the CLI specification and accept either an integer or a string.

Yet another way would be to keep the `port`/`portEnd` and `reject`/`rejectErrno` as is but just change the `fdName` option to something like `systemdFdName`.

---

Given the following CLI invocation:

```sh-session
$ ip2unix -r port=80-443,systemd=foo \
          -r port=53,reject \
          -r port=6667,reject=EPERM \
          -r systemd \
          ...
```

... here are how the ideas above would look like in rule file format:

```yaml
- port:
    start: 80
    end: 443
  systemd:
    enable: true
    fdName: foo
- port:
    exact: 53
  reject:
    enable: true
- port:
    exact: 6667
  reject:
    enable: true
    errno: EPERM
- systemd:
    enable: true
```

```yaml
- port: 80-443
  systemd: foo
- port: 53
  reject: true
- port: 6667
  reject: EPERM
- systemd: true
```

```yaml
- port: 80
  portEnd: 443
  systemd: true
  systemdFdName: foo
- port: 53
  reject: true
- port: 6667
  reject: true
  rejectErrno: EPERM
- systemd: true
```

Cc: @Profpatsch
Cc: @kyren for providing helpful input for designing the CLI specification format back then