### PR TITLE
Build fixups for version 2.1.2

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -47,5 +47,12 @@ pkgs.stdenv.mkDerivation rec {
       echo "ERROR: Manual page hasn't been generated." >&2
       exit 1
     fi
+
+    diff -u <(
+      find "$src/src" -iname '*.cc' -type f -exec \
+        sed -n -e '/^ *#/!s/^.*WRAP_SYM(\([^)]\+\)).*/\1/p' {} + | sort
+    ) <(
+      nm --defined-only -g "$out/lib/libip2unix.so" | cut -d' ' -f3- | sort
+    )
   '';
 }

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ add_project_arguments(cc.get_supported_arguments(warning_flags),
 python = import('python').find_installation('python3')
 
 cflags = ['-DVERSION="' + meson.project_version() + '"']
+cflags += ['-fPIC']
 main_cflags = []
 lib_cflags = []
 

--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,7 @@ cflags = ['-DVERSION="' + meson.project_version() + '"']
 cflags += ['-fPIC']
 main_cflags = []
 lib_cflags = []
+lib_ldflags = []
 
 deps = [
   dependency('yaml-cpp', version: '>=0.5.0'),
@@ -57,11 +58,12 @@ subdir('src')
 generate_sym_map = [python, script_gensyms, '@INPUT@']
 sym_map = custom_target('symmap', input: lib_sources, output: 'symbols.map',
                         command: generate_sym_map, capture: true)
-cflags += ['-Wl,--version-script,@0@'.format(sym_map.full_path())]
+lib_ldflags += ['-Wl,--version-script,@0@'.format(sym_map.full_path())]
 
 libip2unix = shared_library('ip2unix', lib_sources, install: true,
                             dependencies: deps, link_depends: sym_map,
                             cpp_args: lib_cflags + cflags,
+                            link_args: lib_ldflags,
                             include_directories: includes)
 
 ip2unix = executable('ip2unix', main_sources, install: true,

--- a/release.nix
+++ b/release.nix
@@ -160,6 +160,10 @@ let
     '';
   });
 
+  tests.no-hardening = fullForEachSystem (pkgs: {
+    hardeningDisable = [ "all" ];
+  });
+
   tests.vm = {
     systemd = lib.genAttrs systems (system: (import ./tests/vm/systemd.nix {
       inherit system;

--- a/scripts/gensyms.py
+++ b/scripts/gensyms.py
@@ -1,7 +1,7 @@
 import re
 import sys
 
-WRAP_SYM_RE = re.compile(r'WRAP_SYM\s*\(\s*(\S+)\s*\)')
+WRAP_SYM_RE = re.compile(r'WRAP_SYM\s*\(\s*(\S+?)\s*\)')
 
 symbols = []
 for path in sys.argv[1:]:


### PR DESCRIPTION
Version 2.1.2 has introduced a few issues (eg. #10, #11) which particularly surface on non-NixOS systems. This branch should essentially fix building the library/executable as position-independent code and also fix our linker script.

All those issues were introduced with 8e10ef2d1d76ba8835735eaab167e77de34df88a.

Hydra jobset: https://headcounter.org/hydra/jobset/ip2unix/build-fixups
Cc: @etam