### PR TITLE
sockopts: Collect and replay epoll_ctl calls

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,7 +23,8 @@ pkgs.stdenv.mkDerivation rec {
       ];
       isMatching = { type, name }: type == type && relPath == name;
       isToplevel = lib.any isMatching toplevel;
-    in if type == "directory" && relPath == "tests/vm" then false
+      excludedTestDirs = [ "tests/vm" "tests/programs" ];
+    in if type == "directory" && lib.elem relPath excludedTestDirs then false
        else builtins.match "[^/]+" relPath != null -> isToplevel;
   };
 

--- a/meson.build
+++ b/meson.build
@@ -48,6 +48,10 @@ if systemd_enabled
   cflags += ['-DSYSTEMD_SUPPORT']
 endif
 
+if cc.has_header_symbol('sys/epoll.h', 'epoll_ctl')
+  cflags += ['-DHAS_EPOLL']
+endif
+
 lib_sources = []
 main_sources = []
 includes = []

--- a/release.nix
+++ b/release.nix
@@ -167,12 +167,12 @@ let
     }).test);
   };
 
-  tests.programs = lib.mapAttrs (lib.const (path: let
-    mkProgramTest = system: import path {
+  tests.programs = let
+    mkProgramTest = system: path: import path {
       pkgs = import nixpkgs { inherit system; config = {}; };
     };
-  in lib.genAttrs systems mkProgramTest)) {
-    rsession = tests/programs/rsession.nix;
+  in lib.mapAttrs (lib.const (lib.mapAttrs mkProgramTest)) {
+    rsession.x86_64-linux = tests/programs/rsession.nix;
   };
 
   coverage = fullForEachSystem (pkgs: {

--- a/release.nix
+++ b/release.nix
@@ -167,6 +167,14 @@ let
     }).test);
   };
 
+  tests.programs = lib.mapAttrs (lib.const (path: let
+    mkProgramTest = system: import path {
+      pkgs = import nixpkgs { inherit system; config = {}; };
+    };
+  in lib.genAttrs systems mkProgramTest)) {
+    rsession = tests/programs/rsession.nix;
+  };
+
   coverage = fullForEachSystem (pkgs: {
     nativeBuildInputs = [ pkgs.lcov ];
 

--- a/src/realcalls.hh
+++ b/src/realcalls.hh
@@ -10,6 +10,10 @@
 
 #include "logging.hh"
 
+#if HAS_EPOLL
+#include <sys/epoll.h>
+#endif
+
 /* Let's declare all of the wrappers as extern, so that we can define them by
  * simply overriding IP2UNIX_REALCALL_EXTERN before the #include directive.
  */
@@ -92,6 +96,9 @@ namespace real {
     DLSYM_FUN(getpeername, int, int, struct sockaddr*, socklen_t*);
     DLSYM_FUN(getsockname, int, int, struct sockaddr*, socklen_t*);
     DLSYM_FUN(ioctl, int, int, unsigned long, const void*);
+#ifdef HAS_EPOLL
+    DLSYM_FUN(epoll_ctl, int, int, int, int, struct epoll_event*);
+#endif
 #ifdef SYSTEMD_SUPPORT
     DLSYM_FUN(listen, int, int, int);
 #endif

--- a/src/socket.cc
+++ b/src/socket.cc
@@ -136,6 +136,20 @@ int Socket::ioctl(unsigned long request, const void *arg)
     return ret;
 }
 
+#ifdef HAS_EPOLL
+int Socket::epoll_ctl(int epfd, int op, struct epoll_event *event)
+{
+    int ret = real::epoll_ctl(epfd, op, this->fd, event);
+    if (ret != 0)
+        return ret;
+
+    if (!this->is_unix)
+        this->sockopts.cache_epoll_ctl(epfd, op, event);
+
+    return ret;
+}
+#endif
+
 #ifdef SYSTEMD_SUPPORT
 int Socket::listen(int backlog)
 {

--- a/src/socket.hh
+++ b/src/socket.hh
@@ -52,6 +52,9 @@ struct Socket : std::enable_shared_from_this<Socket>
 
     int setsockopt(int, int, const void*, socklen_t);
     int ioctl(unsigned long, const void*);
+#ifdef HAS_EPOLL
+    int epoll_ctl(int, int, struct epoll_event*);
+#endif
 
     int listen(int);
 #ifdef SYSTEMD_SUPPORT

--- a/tests/programs/rsession.nix
+++ b/tests/programs/rsession.nix
@@ -1,0 +1,23 @@
+# Regression test for https://github.com/nixcloud/ip2unix/issues/6
+{ pkgs ? import <nixpkgs> {}, ip2unix ? import ../.. { inherit pkgs; } }:
+
+pkgs.runCommand "test-rsession" {
+  nativeBuildInputs = [ ip2unix pkgs.R pkgs.rstudio pkgs.curl ];
+  R_HOME = "${pkgs.R}/lib/R";
+  R_SHARE_DIR = "${pkgs.R}/lib/R/share";
+  R_INCLUDE_DIR = "${pkgs.R}/lib/R/include";
+  R_DOC_DIR = "${pkgs.R}/lib/R/doc";
+} ''
+  export HOME="$PWD"
+  export LANG=C
+
+  ip2unix -r path=test.socket rsession \
+    --standalone=1 --program-mode=server --log-stderr=1 \
+    --www-address 127.0.0.1 --www-port 8080 &
+  while [ ! -e test.socket ]; do sleep 1; done
+
+  curl --unix-socket test.socket http://127.0.0.1/ \
+    | grep -qF '<title>RStudio</title>'
+
+  touch "$out"
+''

--- a/tests/test_epoll_ctl.py
+++ b/tests/test_epoll_ctl.py
@@ -1,0 +1,47 @@
+import subprocess
+import sys
+
+from helper import IP2UNIX
+
+TESTPROG = '''
+import socket
+import select
+import os
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+    epoll = select.epoll()
+    epoll.register(server.fileno(), select.EPOLLIN)
+
+    # NOTE: Specifically bind/listen *after* adding the fds to epoll.
+    server.bind(('1.2.3.4', 9191))
+    server.listen(10)
+
+    childpid = os.fork()
+    if childpid == 0:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.connect(('1.2.3.4', 9191))
+            sock.sendall(b'foobar\\n')
+        raise SystemExit
+    else:
+        events = epoll.poll()
+        assert len(events) == 1
+        assert events[0][0] == server.fileno()
+        with server.accept()[0] as conn:
+            assert conn.recv(7) == b'foobar\\n'
+
+status = os.WEXITSTATUS(os.waitpid(childpid, 0)[1])
+print('all fine')
+raise SystemExit(status)
+'''
+
+
+def test_epoll_ctl(tmpdir):
+    sockfile = str(tmpdir.join('foo-%p.sock'))
+    rules = ['-r', 'addr=1.2.3.4,port=9191,path=' + sockfile]
+    cmd = [IP2UNIX] + rules + [sys.executable, '-c', TESTPROG]
+    try:
+        output = subprocess.check_output(cmd)
+    except subprocess.CalledProcessError as e:
+        print(e.output)
+        raise
+    assert b'all fine\n' == output


### PR DESCRIPTION
Some services, particularily the `rsession` command from RStudio and possibly a few others use `epoll_ctl()` for adding the file descriptor of the socket before actually binding the socket.

Since we need `sockaddr` information from the `bind` syscall to be able to decide whether we need to transform the socket into a Unix domain socket or not, we have to handle `epoll_ctl` alongside other socket operations since once we replace the socket the file descriptor added via `epoll_ctl` is no longer valid.

Right now the way we replay `epoll_ctl()` calls is somewhat dumb, so for example if the program is doing `EPOLL_CTL_ADD`, followed by `EPOLL_CTL_MOD`, we essentially repeat the same chain even though we could just shrink it down to one `EPOLL_CTL_ADD`. 

Nevertheless, since `epoll_ctl` usually is only used once per socket, this shouldn't be an issue.

@riedel: Can you please check whether this fixes your issue with `rsession`?