### PR TITLE
Add support for abstract Unix sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Added
 - Deprecation warnings if rules are specified in YAML format.
 - Unlink socket file before `bind` if `SO_REUSEADDR` is used.
+- Support for Linux abstract sockets.
 
 ### Changed
 - Rule files (`-f`) are now just a list of newline-separated rule (`-r`)

--- a/README.adoc
+++ b/README.adoc
@@ -252,6 +252,16 @@ Placeholders are allowed here and are substituted accordingly:
                     datagram socket)
 *%%*;; verbatim `%`
 
+ifndef::without-abstract[]
+*abstract*='NAME'::
+
+An abstract namespace Unix domain socket not being created in the file system
+but solely distinguished by its name.
++
+The placeholders supported in <<rule-socket-path,*path*>> are also supported
+here.
+endif::[]
+
 ifndef::without-systemd[]
 *systemd*[='FD_NAME']::
 Use the socket passed along via file descriptor by systemd instead of

--- a/meson.build
+++ b/meson.build
@@ -104,6 +104,10 @@ if not systemd_enabled
   adoc_attrs += ['-a', 'without-systemd']
 endif
 
+if host_machine.system() != 'linux'
+  adoc_attrs += ['-a', 'without-abstract']
+endif
+
 ################################## MANPAGE ##################################
 
 mandest = join_paths(get_option('prefix'), get_option('mandir'), 'man1')

--- a/src/blackhole.hh
+++ b/src/blackhole.hh
@@ -2,6 +2,8 @@
 #ifndef IP2UNIX_BLACKHOLE_HH
 #define IP2UNIX_BLACKHOLE_HH
 
+#include "socketpath.hh"
+
 #include <optional>
 #include <string>
 
@@ -10,8 +12,9 @@ struct BlackHole
     BlackHole();
     ~BlackHole();
 
-    inline std::optional<std::string> get_path() const {
-        return this->filepath;
+    inline std::optional<SocketPath> get_path() const {
+        if (!this->filepath) return std::nullopt;
+        return SocketPath(SocketPath::Type::FILESYSTEM, *this->filepath);
     }
 
     private:

--- a/src/preload.cc
+++ b/src/preload.cc
@@ -258,7 +258,7 @@ static inline int bind_connect(SockFun &&sockfun, RealFun &&realfun,
 
         if (rule->second.blackhole) {
             sock->blackhole();
-            return std::invoke(sockfun, sock, inaddr, "");
+            return std::invoke(sockfun, sock, inaddr, SocketPath());
         }
 
 #ifdef SYSTEMD_SUPPORT
@@ -272,7 +272,7 @@ static inline int bind_connect(SockFun &&sockfun, RealFun &&realfun,
             LOG(WARNING) << "Systemd file descriptor queue empty, "
                          << "blackholing socket with fd " << fd << '.';
             sock->blackhole();
-            return std::invoke(sockfun, sock, inaddr, "");
+            return std::invoke(sockfun, sock, inaddr, SocketPath());
         }
 #endif
 

--- a/src/rules.hh
+++ b/src/rules.hh
@@ -4,6 +4,8 @@
 
 #include "types.hh"
 
+#include "socketpath.hh"
+
 #include <iostream>
 #include <optional>
 #include <vector>
@@ -24,7 +26,7 @@ struct Rule {
     std::optional<std::string> fd_name = std::nullopt;
 #endif
 
-    std::optional<std::string> socket_path = std::nullopt;
+    std::optional<SocketPath> socket_path = std::nullopt;
 
     bool reject = false;
     std::optional<int> reject_errno = std::nullopt;

--- a/src/sockaddr.hh
+++ b/src/sockaddr.hh
@@ -2,6 +2,8 @@
 #ifndef IP2UNIX_SOCKETADDR_HH
 #define IP2UNIX_SOCKETADDR_HH
 
+#include "socketpath.hh"
+
 #include <cstddef>
 #include <optional>
 #include <string>
@@ -21,7 +23,7 @@ struct SockAddr
     SockAddr();
     SockAddr(const sockaddr*);
 
-    static std::optional<SockAddr> unix(const std::string&);
+    static std::optional<SockAddr> unix(const SocketPath&);
 
     SockAddr copy(void) const;
 
@@ -32,7 +34,7 @@ struct SockAddr
 
     bool set_random_host(void);
 
-    std::optional<std::string> get_sockpath(void) const;
+    std::optional<SocketPath> get_sockpath(void) const;
 
     std::optional<uint16_t> get_port(void) const;
     bool set_port(uint16_t);

--- a/src/socket.hh
+++ b/src/socket.hh
@@ -5,6 +5,7 @@
 #include "blackhole.hh"
 #include "dynports.hh"
 #include "sockaddr.hh"
+#include "socketpath.hh"
 #include "sockopts.hh"
 #include "types.hh"
 
@@ -67,9 +68,9 @@ struct Socket : std::enable_shared_from_this<Socket>
     int activate(const SockAddr&, int, bool);
 #endif
 
-    int bind(const SockAddr&, const std::string&);
+    int bind(const SockAddr&, const SocketPath&);
     std::optional<int> connect_peermap(const SockAddr&);
-    int connect(const SockAddr&, const std::string&);
+    int connect(const SockAddr&, const SocketPath&);
 
     int accept(int, sockaddr*, socklen_t*);
     int getsockname(sockaddr*, socklen_t*);
@@ -77,7 +78,7 @@ struct Socket : std::enable_shared_from_this<Socket>
 
     bool rewrite_src(const SockAddr&, sockaddr*, socklen_t*);
     std::optional<SockAddr> rewrite_dest_peermap(const SockAddr&) const;
-    std::optional<SockAddr> rewrite_dest(const SockAddr&, const std::string&);
+    std::optional<SockAddr> rewrite_dest(const SockAddr&, const SocketPath&);
 
     int dup(void);
     int dup(int, int);
@@ -102,8 +103,8 @@ struct Socket : std::enable_shared_from_this<Socket>
          * and look them up either in the next recvfrom/recvmsg or in a
          * connect().
          */
-        std::unordered_map<SockAddr, std::string> peermap;
-        std::unordered_map<std::string, SockAddr> revpeermap;
+        std::unordered_map<SockAddr, SocketPath> peermap;
+        std::unordered_map<SocketPath, SockAddr> revpeermap;
 
         /* Constructor and reference getter. */
         Socket(int, int, int, int);
@@ -116,13 +117,13 @@ struct Socket : std::enable_shared_from_this<Socket>
         static std::optional<Ptr> find(int);
 
         /* Check if a socket path is registered. */
-        static bool has_sockpath(const std::string&);
+        static bool has_sockpath(const SocketPath&);
 
         /* All INET/INET6 sockets are registered here. */
         static std::unordered_map<int, Ptr> registry;
 
         /* Mapping from bound socket paths to sockets. */
-        static std::unordered_set<std::string> sockpath_registry;
+        static std::unordered_set<SocketPath> sockpath_registry;
 
         /* Whether the socket has been converted to an AF_UNIX socket. */
         bool is_unix = false;
@@ -141,7 +142,7 @@ struct Socket : std::enable_shared_from_this<Socket>
         bool make_unix(int = -1);
         bool create_binding(const SockAddr&);
 
-        std::string format_sockpath(const std::string&, const SockAddr&) const;
+        SocketPath format_sockpath(const SocketPath&, const SockAddr&) const;
 };
 
 #endif

--- a/src/socketpath.hh
+++ b/src/socketpath.hh
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+#ifndef IP2UNIX_SOCKPATH_HH
+#define IP2UNIX_SOCKPATH_HH
+
+#include <string>
+
+struct SocketPath {
+    enum class Type { ABSTRACT, FILESYSTEM };
+
+    inline SocketPath() : type(Type::FILESYSTEM), value() {}
+    inline SocketPath(Type t, const std::string &v) : type(t), value(v) {}
+
+    inline bool operator==(const SocketPath &other) const {
+        return this->type == other.type && this->value == other.value;
+    }
+
+    inline bool operator!=(const SocketPath &other) const {
+        return this->type != other.type || this->value != other.value;
+    }
+
+    inline bool is_real_file() const {
+        return this->type == Type::FILESYSTEM;
+    }
+
+    Type type;
+    std::string value;
+};
+
+namespace std {
+    template<> struct hash<SocketPath> {
+        std::size_t operator()(const SocketPath &addr) const {
+            return std::hash<std::string>()(addr.value); // TODO
+        }
+    };
+}
+
+#endif

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,4 +1,5 @@
 import json
+import sys
 import subprocess
 
 from contextlib import contextmanager
@@ -8,7 +9,7 @@ from conftest import IP2UNIX, LIBIP2UNIX, SYSTEMD_SUPPORT, SYSTEMD_SA_PATH
 
 __all__ = ['IP2UNIX', 'LIBIP2UNIX', 'SYSTEMD_SUPPORT', 'SYSTEMD_SA_PATH',
            'ip2unix', 'systemd_only', 'non_systemd_only',
-           'systemd_sa_helper_only']
+           'systemd_sa_helper_only', 'abstract_sockets_only']
 
 
 @contextmanager
@@ -29,4 +30,8 @@ non_systemd_only = pytest.mark.skipif(
 )
 systemd_sa_helper_only = pytest.mark.skipif(
     SYSTEMD_SA_PATH is None, reason="no 'systemd-socket-activate' helper"
+)
+abstract_sockets_only = pytest.mark.skipif(
+    sys.platform != 'linux',
+    reason='abstract sockets are only supported on Linux'
 )

--- a/tests/test_abstract_socket.py
+++ b/tests/test_abstract_socket.py
@@ -1,0 +1,30 @@
+import socket
+import subprocess
+import sys
+
+from helper import abstract_sockets_only, IP2UNIX
+
+TESTPROG = r'''
+import socket
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.connect(('4.3.2.1', 4321))
+    sock.sendall(b'hello')
+    assert sock.recv(5) == b'world'
+'''
+
+
+@abstract_sockets_only
+def test_abstcact_socket():
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+        sock.bind('\0abstest')
+        sock.listen(10)
+
+        cmd = [IP2UNIX]
+        cmd += ['-r', 'addr=4.3.2.1,abstract=abstest']
+        cmd += [sys.executable, '-c', TESTPROG]
+
+        with subprocess.Popen(cmd, stdout=subprocess.PIPE), \
+             sock.accept()[0] as conn:
+            assert conn.recv(5) == b'hello'
+            conn.sendall(b'world')

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -135,6 +135,13 @@ class TcpConnectionTest(unittest.TestCase):
         finally:
             os.unlink(extrasock)
 
+    @helper.abstract_sockets_only
+    def test_abstract_socket(self):
+        srule = {'direction': 'incoming', 'abstract': 'a%p'}
+        crule = {'direction': 'outgoing', 'abstract': 'a%p'}
+        with self.run_server([srule], '1.2.3.4', 929):
+            self.assert_client([crule], '1.2.3.0', 929)
+
 
 class UdpConnectionTest(TcpConnectionTest):
     SOTYPE = 'udp'

--- a/tests/test_rule_file.py
+++ b/tests/test_rule_file.py
@@ -5,7 +5,8 @@ import unittest
 
 from tempfile import NamedTemporaryFile
 
-from helper import IP2UNIX, systemd_only, non_systemd_only
+from helper import IP2UNIX, systemd_only, non_systemd_only, \
+                   abstract_sockets_only
 
 
 class RuleFileTest(unittest.TestCase):
@@ -69,6 +70,18 @@ class RuleFileTest(unittest.TestCase):
 
     def test_absolute_socket_path(self):
         self.assert_good_rules([{'socketPath': '/xxx'}])
+
+    @abstract_sockets_only
+    def test_valid_abstract_name(self):
+        self.assert_good_rules([{'abstract': 'foobar'}])
+
+    @abstract_sockets_only
+    def test_invalid_abstract_name(self):
+        self.assert_bad_rules([{'abstract': ''}])
+
+    @abstract_sockets_only
+    def test_abstract_and_path(self):
+        self.assert_bad_rules([{'abstract': 'xxx', 'socketPath': '/xxx'}])
 
     def test_invalid_enums(self):
         self.assert_bad_rules([{'socketPath': '/bbb', 'direction': 111}])


### PR DESCRIPTION
Abstract Unix domain sockets are a Linux extension, which allows to bind a socket to a name not bound to a particular file system path.

While I personally don't have a need for this, since I actually *want* to use file system paths in order to separate permissions, it does however make sense to support it for the sake of completeness.