### PR TITLE
Add support for Mac OS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,9 @@ jobs:
 
   macos:
     runs-on: macos-latest
+    if: github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name !=
+      github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,3 +21,20 @@ jobs:
         with:
           name: Linux_Meson_Testlog
           path: build/meson-logs/testlog.txt
+
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - run: brew install yaml-cpp asciidoctor
+      - run: pip install meson ninja
+      - run: meson setup build
+      - run: meson test -C build -v
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: MacOS_Meson_Testlog
+          path: build/meson-logs/testlog.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: '3.x'
       - run: brew install yaml-cpp asciidoctor
-      - run: pip install meson ninja
+      - run: pip install meson ninja pytest
       - run: meson setup build
       - run: meson test -C build -v
       - uses: actions/upload-artifact@v1

--- a/src/sockaddr.cc
+++ b/src/sockaddr.cc
@@ -114,11 +114,23 @@ bool SockAddr::set_host(const SockAddr &other)
     return false;
 }
 
-bool SockAddr::set_host(const ucred &peercred)
+#if defined(SO_PEERCRED)
+#define PEERCRED_TYPE ucred
+#define PEERCRED_PID peercred.pid
+#define PEERCRED_GID peercred.gid
+#define PEERCRED_UID peercred.uid
+#else
+#define PEERCRED_TYPE xucred
+#define PEERCRED_PID peercred.cr_pid
+#define PEERCRED_GID peercred.cr_gid
+#define PEERCRED_UID peercred.cr_uid
+#endif
+
+bool SockAddr::set_host(const PEERCRED_TYPE &peercred)
 {
     if (this->is_inet4()) {
         this->cast4()->sin_addr.s_addr =
-            htonl(static_cast<uint32_t>(peercred.pid));
+            htonl(static_cast<uint32_t>(PEERCRED_PID));
         return true;
     }
 
@@ -128,12 +140,15 @@ bool SockAddr::set_host(const ucred &peercred)
         addr->sin6_addr.s6_addr[1] = 0x80;
         addr->sin6_addr.s6_addr[2] = 0x00;
         addr->sin6_addr.s6_addr[3] = 0x00;
-        uint32_t part = htonl(static_cast<uint32_t>(peercred.uid));
+        uint32_t part = htonl(static_cast<uint32_t>(PEERCRED_UID));
         memcpy(addr->sin6_addr.s6_addr + 4, &part, 4);
-        part = htonl(static_cast<uint32_t>(peercred.gid));
+// XXX!
+#if defined(SO_PEERCRED)
+        part = htonl(static_cast<uint32_t>(PEERCRED_GID));
         memcpy(addr->sin6_addr.s6_addr + 8, &part, 4);
-        part = htonl(static_cast<uint32_t>(peercred.pid));
+        part = htonl(static_cast<uint32_t>(PEERCRED_PID));
         memcpy(addr->sin6_addr.s6_addr + 12, &part, 4);
+#endif
         return true;
     }
 

--- a/src/sockaddr.hh
+++ b/src/sockaddr.hh
@@ -13,6 +13,10 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
+#if defined(__APPLE__)
+#include <sys/ucred.h>
+#endif
+
 struct sockaddr_in6;
 struct sockaddr_in;
 
@@ -27,7 +31,11 @@ struct SockAddr
 
     std::optional<std::string> get_host(void) const;
     bool set_host(const std::string&);
+#if defined(SO_PEERCRED)
     bool set_host(const ucred&);
+#else
+    bool set_host(const xucred&);
+#endif
     bool set_host(const SockAddr&);
 
     bool set_random_host(void);

--- a/src/socket.cc
+++ b/src/socket.cc
@@ -15,6 +15,10 @@
 #include <stdint.h>
 #include <unistd.h>
 
+#if defined(__APPLE__)
+#include <sys/ucred.h>
+#endif
+
 std::optional<Socket::Ptr> Socket::find(int fd)
 {
     using itype = decltype(Socket::registry)::const_iterator;
@@ -272,10 +276,19 @@ bool Socket::create_binding(const SockAddr &addr)
         if (!local.set_host(addr))
             return false;
     } else {
+#if defined(SO_PEERCRED)
         ucred local_cred;
         local_cred.uid = getuid();
         local_cred.gid = getgid();
         local_cred.pid = getpid();
+#else
+        xucred local_cred;
+        local_cred.cr_uid = getuid();
+        /* XXX!
+        local_cred.cr_gid = getgid();
+        local_cred.cr_pid = getpid();
+        */
+#endif
 
         // Our local sockaddr, which we only need if we didn't have a
         // bind() before our connect.
@@ -460,11 +473,20 @@ int Socket::accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
     } else {
         // We use SO_PEERCRED to get uid, gid and pid in order to generate
         // unique IP addresses.
+#if defined(SO_PEERCRED)
         ucred peercred;
         socklen_t len = sizeof peercred;
 
         if (getsockopt(sockfd, SOL_SOCKET, SO_PEERCRED, &peercred, &len) == -1)
             return -1;
+#else
+        xucred peercred;
+        socklen_t len = sizeof peercred;
+
+        if (getsockopt(sockfd, SOL_LOCAL, LOCAL_PEERCRED, &peercred,
+                       &len) == -1)
+            return -1;
+#endif
 
         if (!peer.set_host(peercred)) {
             errno = EINVAL;


### PR DESCRIPTION
This is a WIP branch to implement support for Mac OS X, which in *theory* should work since it has a similar mechanism (`DYLD_INSERT_LIBRARIES`) to `LD_PRELOAD` on GNU/Linux.

Fundamental issues:

  * [ ] Find a way to handle PID/GID in `LOCAL_PEERCRED`. It seems that there is only `xucred.cr_uid`, but in order to provide fake client IPs we need at least the peer PID to properly distinguish the individual peers.
  * [x] ~~We can't use `std::filesystem` yet, because Ubuntu 18.04 is still using GCC 7. Find a less ugly way to `get_current_dir_name` in a cross-platform way.~~ According to https://ubuntu.com/18-04, the standard support has expired on 31 May 2023.