### PR TITLE
README: Document rule matching behaviour

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -413,7 +413,7 @@ endif::[]
 Reject calls to *connect* and *bind* with `EACCES` by default or the 'ERRNO'
 specified either via name or as an integer.
 
-*blackhole*::
+[[blackhole]]*blackhole*::
 When binding the socket, use a temporary file system path and *unlink* it
 shortly after the *bind*. This is a way to deactivate a specific socket
 without the application noticing.
@@ -454,9 +454,10 @@ specificity) that matches is either turned into a Unix domain socket,
 blackholed, rejected or ignored depending on the action specified.
 
 If a listening socket is matched by the same rule multiple times, subsequent
-sockets are automatically blackholed. The reason for this is that it requires
-fewer rules for common things, such as for example handling services that bind
-to *both* IPv4 and IPv6 addresses.
+sockets are automatically <<blackhole,blackholed>> (that is, deactivated
+without the application noticing). The reason for doing this is that it
+requires fewer rules for common things, such as for example handling services
+that bind to *both* IPv4 and IPv6 addresses.
 
 Let's say we have *someprogram*, which binds to +127.0.0.1:1234+ and
 +[::1]:1234+ in that order. All we need to do here is match on port 1234 and

--- a/README.adoc
+++ b/README.adoc
@@ -447,6 +447,52 @@ Placeholders are allowed here and are substituted accordingly:
 *%t*;; socket type (`tcp`, `udp` or `unknown`)
 *%%*;; verbatim `%`
 
+== Rule matching behaviour
+
+Each rule is matched in the specified order and the first socket (regardless of
+specificity) that matches is either turned into a Unix domain socket,
+blackholed, rejected or ignored depending on the action specified.
+
+If a listening socket is matched by the same rule multiple times, subsequent
+sockets are automatically blackholed. The reason for this is that it requires
+fewer rules for common things, such as for example handling services that bind
+to *both* IPv4 and IPv6 addresses.
+
+Let's say we have *someprogram*, which binds to +127.0.0.1:1234+ and
++[::1]:1234+ in that order. All we need to do here is match on port 1234 and
+only the first (+127.0.0.1:1234+) socket will actually bind to +/foo/bar+, the
+second (+[::1]:1234+) will be blackholed and is not reachable:
+
+[source,sh-session]
+-----------------------------------------------------------------------------
+$ ip2unix -r in,port=1234,path=/foo/bar someprogram
+-----------------------------------------------------------------------------
+
+Note that this is *only* the case if both end up using the *same* socket path.
+If instead something like this is used, none of the two sockets is blackholed:
+
+[source,sh-session]
+-----------------------------------------------------------------------------
+$ ip2unix -r in,port=1234,path=/foo/bar-%a someprogram
+-----------------------------------------------------------------------------
+
+This will result in two sockets:
+
+. +/foo/bar-127.0.0.1+ for the socket originally binding to +127.0.0.1:1234+.
+. +/foo/bar-::1+ for the socket originally binding to +[::1]:1234+.
+
+The reason we blackhole subsequent sockets that lead to the same part is to
+make the common case less verbose to express.
+
+If we would not blackhole the socket and the matcher would simply fall through
+to the next rule, the following would be required to achieve the same behaviour
+that we have in the first example:
+
+[source,sh-session]
+-----------------------------------------------------------------------------
+$ ip2unix -r in,port=1234,path=/foo/bar -r in,port=1234,blackhole someprogram
+-----------------------------------------------------------------------------
+
 == Examples
 
 === Simple HTTP client/server

--- a/README.adoc
+++ b/README.adoc
@@ -409,14 +409,17 @@ distinguish between several socket units. This corresponds to the {fdname}
 systemd socket option.
 endif::[]
 
-*reject*[='ERRNO']::
+[[reject]]*reject*[='ERRNO']::
 Reject calls to *connect* and *bind* with `EACCES` by default or the 'ERRNO'
 specified either via name or as an integer.
 
 [[blackhole]]*blackhole*::
-When binding the socket, use a temporary file system path and *unlink* it
-shortly after the *bind*. This is a way to deactivate a specific socket
-without the application noticing.
+Turn the socket into a Unix domain socket but do not make it available for
+clients to connect. This is useful to deactive certain sockets without causing
+errors in the application (unlike <<reject,*reject*>>).
++
+Technically, this means that we *bind* to a Unix socket using a temporary file
+system path and *unlink* it shortly thereafter.
 
 *ignore*::
 Prevents a socket from being converted to a Unix domain socket if this is


### PR DESCRIPTION
[Rendered version](https://github.com/nixcloud/ip2unix/blob/document-rule-matching/README.adoc#rule-matching-behaviour)

I wasn't sure whether I'd want to change the behaviour of blackholing subsequent sockets leading to the same socket path, so I searched for public code on GitHub where I'm using `ip2unix` in practice:

https://github.com/aszlig/avonc/blob/8c025c2d283a11/modules/redis.nix#L33

```sh-session
$ ip2unix -r port=10,systemd ...
```

https://github.com/aszlig/avonc/blob/01dead4e3de2cb/osrm/default.nix#L140

```sh-session
$ ip2unix -r in,systemd -r reject ...
```

https://github.com/aszlig/avonc/blob/26bb761105c8ba/talk/external-signaling/default.nix#L420

```sh-session
$ ip2unix -r in,port=8188,systemd ...
```

https://github.com/headcounter/shabitica/blob/fb917c6a6c8539/tests/e2e/default.nix#L98

```sh-session
$ ip2unix -r addr=127.0.0.1,port=8100,path=shabitica.sock
```

https://github.com/aszlig/avonc/blob/ec07c35d744de2/libreoffice-online/default.nix#L212-L214

```sh-session
$ ip2unix -r out,port=9981,ignore \
>         -r out,path=/run/libreoffice-online/internal.socket \
>         ...
```

https://github.com/nixcloud/nixcloud-webservices/blob/e324a8aa9e1bc89/modules/web/messaging/rabbitmq/default.nix#L166-L183

```sh-session
$ ip2unix -r in,tcp,port=5671-5672,path=.../rabbitmq.socket \
>         -r in,tcp,port=25672,path=.../rabbitmqctl.socket \
>         -r out,port=35672-35682,path=.../rabbitmqctl-%p.socket \
>         -r out,tcp,port=4369,path=.../epmd.socket \
>         -r in,tcp,port=4369,reject=EADDRINUSE \
>         -r port=0,path=.../.epmd-rabbitmq-%p.socket \
>         -r path=/tmp/xxx-%a-%t-%p.socket \
>         ...
```

https://github.com/aszlig/avonc/blob/34d9794487e36ba/xmpp/default.nix#L33-L70

```sh-session
$ ip2unix -r in,port=4369,reject=EADDRINUSE \
>         -r in,port=0,path=/run/mongooseim-epmd/port-%p.socket \
>         -r out,addr=127.0.0.100,port=5432,path=/run/postgresql/.s.PGSQL.5432 \
>         -r out,tcp,port=4369,path=/run/mongooseim-epmd.socket \
>         -r out,addr=127.0.0.1,path=/run/mongooseim-epmd/port-%p.socket \
>         -r in,port=5280,systemd \
>         -r out,addr=127.0.0.200,port=7,path=/run/mongooseim-internal/auth.socket \
>         ...
```

The last three are pretty complicated and also could be simplified in todays version of ip2unix, but the all the other examples benefit from the "lazy" approach (blackholing subsequent sockets) to be much more concise.

Even when looking closer at the more complicated examples, some of them still benefit from that behaviour, since for example epmd (port 4369) could possibly [bind to multiple addresses](https://erlang.org/doc/man/epmd.html#regular-options). The same is true for RabbitMQ ([`Default: an empty string, meaning "bind to all network interfaces".`](https://www.rabbitmq.com/configure.html#supported-environment-variables)).

Of course, apart from just my own examples, I also looked on how others are using it:

https://github.com/grahamc/nixos-config/blob/91ce27f375500ff/packages/aenea/service.nix#L6

```sh-session
$ ip2unix -r in,path=.../aenea.sock ...
```

I don't know a whole lot about Aenea but from [its source](https://github.com/dictation-toolbox/aenea/blob/50af9e81b47565/client/aenea/communications.py#L33-L37) it seems that it only binds to one address, but @grahamc still seems to use the "lazy" approach here, which I think is perfectly fine.

https://github.com/openlab-aux/vuizvui/blob/bfee3147aaf5216/machines/profpatsch/legosi.nix#L74-L76

```sh-session
$ ip2unix -r addr=1.2.3.4,port=6667,path=/run/bitlbee.socket ...
```

The example from @Profpatsch however is a little more specific, so in this case, blackholing of the socket would only take ploce if BitlBee would bind to the same address and port, but using UDP instead.

https://github.com/nixcloud/ip2unix/pull/13#issuecomment-635423354

```sh-session
$ ip2unix -r path=rsession.sock ...
```

An example from @riedel, which is in another "lazy" (or let's say "concise") usage.

Given that one can *always* be more specific and so prevent anything from being blackholed, I opted to not change the behaviour and just document the current behaviour so that it's more clear to people what's happening in such a situation and why.