### PR TITLE
Fix preliminary unlinking of socket file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 - Support for Linux abstract sockets.
 - Support for matching an existing Unix domain socket or abstract socket.
 - Add `stream`/`datagram` aliases for `tcp`/`udp` socket types.
+- Add flag to prevent unlinking of socket files when closing sockets.
 
 ### Changed
 - Rule files (`-f`) are now just a list of newline-separated rule (`-r`)

--- a/README.adoc
+++ b/README.adoc
@@ -282,6 +282,15 @@ Placeholders are allowed here and are substituted accordingly:
                     datagram socket)
 *%%*;; verbatim `%`
 
+*noremove*::
+If this flag is given in conjunction with a <<rule-socket-path,*path*>>, the
+socket file is not removed when the socket is closed.
++
+This works around an issue with more complex programs that spawn subprocesses
+or threads without sharing memory or cloning the file descriptor table. In some
+scenarios *ip2unix* might be unable to correctly track sockets and might
+accidentally remove the socket file too early.
+
 ifndef::without-abstract[]
 *abstract*='NAME'::
 An abstract namespace Unix domain socket not being created in the file system

--- a/src/serial.cc
+++ b/src/serial.cc
@@ -170,6 +170,7 @@ void serialise(const SocketPath &path, std::ostream &out)
     }
 
     serialise(path.value, out);
+    serialise(path.unlink, out);
 }
 
 MaybeError deserialise(std::istream &in, SocketPath *out)
@@ -195,7 +196,9 @@ MaybeError deserialise(std::istream &in, SocketPath *out)
                  + c + "' used as socket path type.";
     }
 
-    return deserialise(in, &out->value);
+    MaybeError err;
+    if ((err = deserialise(in, &out->value))) return err;
+    return deserialise(in, &out->unlink);
 }
 
 void serialise(const Rule &rule, std::ostream &out)

--- a/src/socketpath.hh
+++ b/src/socketpath.hh
@@ -7,8 +7,12 @@
 struct SocketPath {
     enum class Type { ABSTRACT, FILESYSTEM };
 
-    inline SocketPath() : type(Type::FILESYSTEM), value() {}
-    inline SocketPath(Type t, const std::string &v) : type(t), value(v) {}
+    inline SocketPath()
+        : type(Type::FILESYSTEM), value(), unlink(true) {}
+    inline SocketPath(Type t, const std::string &v)
+        : type(t), value(v), unlink(true) {}
+    inline SocketPath(Type t, const std::string &v, bool ul)
+        : type(t), value(v), unlink(ul) {}
 
     inline bool operator==(const SocketPath &other) const {
         return this->type == other.type && this->value == other.value;
@@ -24,6 +28,7 @@ struct SocketPath {
 
     Type type;
     std::string value;
+    bool unlink;
 };
 
 namespace std {

--- a/tests/test_preliminary_unlink.py
+++ b/tests/test_preliminary_unlink.py
@@ -1,0 +1,47 @@
+import sys
+import subprocess
+import socket
+
+from helper import IP2UNIX
+
+TESTPROG = r'''
+import os
+import sys
+import socket
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.bind(('1.2.3.4', 1234))
+sock.listen(10)
+
+childpid = os.fork()
+if childpid == 0:
+    os.closerange(3, 65536)
+    raise SystemExit
+
+assert os.WEXITSTATUS(os.waitpid(childpid, 0)[1]) == 0
+
+sys.stdout.write('ready\n')
+sys.stdout.flush()
+
+with sock.accept()[0] as conn:
+    assert conn.recv(3) == b'foo'
+'''
+
+
+def test_preliminary_unlink(tmpdir):
+    """
+    Regression test for https://github.com/nixcloud/ip2unix/issues/16
+    """
+    sockfile = str(tmpdir.join('test.sock'))
+
+    cmd = [
+        IP2UNIX, '-r', 'port=1234,addr=1.2.3.4,noremove,path=' + sockfile,
+        sys.executable, '-c', TESTPROG,
+    ]
+
+    with subprocess.Popen(cmd, stdout=subprocess.PIPE) as client:
+        assert client.stdout.readline() == b'ready\n'
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.connect(sockfile)
+            sock.sendall(b'foo')
+        assert client.wait() == 0

--- a/tests/test_program_args.py
+++ b/tests/test_program_args.py
@@ -45,10 +45,10 @@ def test_rule_longopts(tmpdir):
         stdout = subprocess.check_output(deprecated_cmd,
                                          stderr=subprocess.STDOUT)
         assert b"is deprecated" in stdout
-        assert b"path: /test\n" in stdout
+        assert b"path: /test (will" in stdout
 
     stdout = subprocess.check_output([IP2UNIX, '-cp', '--rule', 'path=/test'])
-    assert b"path: /test\n" in stdout
+    assert b"path: /test (will" in stdout
 
 
 def test_no_program():

--- a/tests/test_rule_args.py
+++ b/tests/test_rule_args.py
@@ -42,7 +42,7 @@ class RulesTest(unittest.TestCase):
         }
         for val, expect in fixtures.items():
             stdout, stderr = self.check_rules("path=" + val)
-            self.assertIn("Socket path: " + expect + "\n", stdout)
+            self.assertIn("Socket path: " + expect + " (will", stdout)
 
     def test_good(self):
         fixtures = {
@@ -54,9 +54,9 @@ class RulesTest(unittest.TestCase):
             "path=/eee\\\\,out": "Direction: outgoing\n",
             "path=/fff\\\\,tcp,udp": "IP Type: UDP\n",
             "path=/ggg\\\\,in,out": "Direction: outgoing\n",
-            "path=/hhh\\\\": "Socket path: /hhh\\\n",
+            "path=/hhh\\\\": "Socket path: /hhh\\ (will",
             "path=/iii\\,,out": "IP Type: TCP and UDP\n",
-            "path=/jjj\\,,in": "Socket path: /jjj,\n",
+            "path=/jjj\\,,in": "Socket path: /jjj, (will",
             "path=/kkk\\\\,stream": "IP Type: TCP\n",
             "path=/lll\\\\,datagram": "IP Type: UDP\n",
             "path=/mmm\\\\,dgram": "IP Type: UDP\n",
@@ -65,8 +65,9 @@ class RulesTest(unittest.TestCase):
             "reject=999999": "calls with errno <unknown>.\n",
             "in,blackhole": "Blackhole the socket.\n",
             "in,ignore": "Don't handle this socket.\n",
-            "path=foo": "Socket path: " + os.getcwd() + "/foo\n",
+            "path=foo": "Socket path: " + os.getcwd() + "/foo (will",
             "from-unix=xyz,path=/foo": "domain socket path matching: xyz\n",
+            "path=bar,noremove": "will not be removed on close",
         }
         for val, expect in fixtures.items():
             stdout, stderr = self.check_rules(val)

--- a/tests/test_rule_file.py
+++ b/tests/test_rule_file.py
@@ -193,6 +193,22 @@ class RuleFileTest(unittest.TestCase):
     def test_ignore_with_blackhole(self):
         self.assert_bad_rules([{'blackhole': True, 'ignore': True}])
 
+    def test_noremove_without_sockpath(self):
+        self.assert_bad_rules([{'reject': True, 'noRemove': True}])
+        self.assert_bad_rules([{'blackhole': True, 'noRemove': True}])
+        self.assert_bad_rules([{'ignore': True, 'noRemove': True}])
+
+    @systemd_only
+    def test_noremove_with_systemd(self):
+        self.assert_bad_rules([{'socketActivation': True, 'noRemove': True}])
+
+    @abstract_sockets_only
+    def test_noremove_with_abstract(self):
+        self.assert_bad_rules([{'abstract': 'foo', 'noRemove': True}])
+
+    def test_noremove_with_sockpath(self):
+        self.assert_good_rules([{'socketPath': '/foo', 'noRemove': True}])
+
     @systemd_only
     def test_ignore_with_systemd(self):
         self.assert_bad_rules([{'socketActivation': True, 'ignore': True}])
@@ -274,17 +290,17 @@ class RuleFileTest(unittest.TestCase):
             b'  IP Type: TCP and UDP\n'
             b'  Address: <any>\n'
             b'  Port: 1234\n'
-            b'  Socket path: /foo\n'
+            b'  Socket path: /foo (will be removed on close)\n'
             b'Rule #2:\n'
             b'  Direction: incoming\n'
             b'  IP Type: TCP and UDP\n'
             b'  Address: 9.8.7.6\n'
             b'  Port: <any>\n'
-            b'  Socket path: /bar\n'
+            b'  Socket path: /bar (will be removed on close)\n'
             b'Rule #3:\n'
             b'  Direction: outgoing\n'
             b'  IP Type: TCP and UDP\n'
             b'  Address: <any>\n'
             b'  Port: 4321\n'
-            b'  Socket path: /foobar\n'
+            b'  Socket path: /foobar (will be removed on close)\n'
         )

--- a/tests/unit/serial.cc
+++ b/tests/unit/serial.cc
@@ -159,7 +159,8 @@ static unsigned long test_rule(unsigned long seed)
     std::optional<std::string> value = CHOOSE(strings);
     if (value) {
         SocketPath::Type socketpathtype = CHOOSE(socketpathtypes);
-        rule.action.socket_path = SocketPath(socketpathtype, *value);
+        bool unlink = CHOOSE(bools);
+        rule.action.socket_path = SocketPath(socketpathtype, *value, unlink);
     }
     rule.action.reject = CHOOSE(bools);
     rule.action.reject_errno = CHOOSE(ints);


### PR DESCRIPTION
Currently, this only consists of a regression test but I haven't yet found a very good solution to address this problem.

If we were to mainly tackle the `unlink` issue (#16), we could just introduce a new flag to disable unlinking altogether.

Unfortunately, this doesn't fully address the actual issue, which is about how we handle sharing versus copying of memory and file descriptors across processes.

For most programs in the wild, this isn't an issue because most of them don't do very complex socket operations, but occasionally - and especially when interacting with other subprocesses - we **do** run into this issue and then we end up having a very hard time to debug what's going on.

So to describe the issue in more detail, here is a simplified version of how `ip2unix` currently tracks socket file descriptors:

  * We have an internal registry, which maps the file descriptors of the current process to our internal [Socket](https://github.com/nixcloud/ip2unix/blob/42a3cc0c334c01b19610c1d51b863680060a18c6/src/socket.cc) state.
  * Whenever we get a new `socket` call, we insert the file descriptor into the registry. At this point, we can't make a final decision about how to handle this socket, because we only know the socket family (eg. `AF_INET` or `AF_INET6`) but no details about ports or IP addresses.
  * Once we get a `bind` or `connect` call, we look up the file descriptor in the registry and see whether we have a matching rule.
  * If the rule matches, we go ahead and execute the corresponding action (eg. convert to Unix socket, blackhole, reject, etc...).
  * If it doesn't match, we remove the file descriptor from the registry and invoke the real `bind`/`connect` function.

This all works fine if everything is run in order and without any multiprocessing involved, but as soon as the application invokes `clone`, things start to get ugly.

Essentially we have two `clone` flags that are problematic:

  * `CLONE_VM`

    **If set**, the calling process and the child process run in the same memory space. In particular, memory writes performed by the calling process or by the child process are also visible in the other process.
    **If not set**, the child process runs in a separate copy of the memory space of the calling process at the time of the clone call. Memory writes or file mappings/unmappings performed by one of the processes do not affect the other.
  * `CLONE_FILES`

    **If set**, the calling process and the child process share the same file descriptor table. Any file descriptor created by the calling process or by the child process is also valid in the other process.
    **If not set**, the child process inherits a copy of all file descriptors opened in the calling process at the time of the clone call. Subsequent operations that open or close file descriptors, or change file descriptor flags, performed by either the calling process or the child process do not affect the other process.

See the [clone(2)](https://www.man7.org/linux/man-pages/man2/clone.2.html) manpage for more detailed information.

Here is how these flags are affecting us (btw. this also includes syscalls such as `fork` or libc functions such as `daemon`):

 * :smiley: `CLONE_VM` | `CLONE_FILES`

   Processes **share** memory and also **share** file descriptors, which essentially means that we don't need to do anything, because the registry *and* the file descriptor table are *still* in par.

 * :neutral_face: `CLONE_VM`

   Little more tricky, we have one **shared** registry across both processes, but the file descriptor tables are **copied**. This means that whenever we're closing a socket in the second process, we can *not* yet `unlink` the socket file until the file descriptor is also closed in the first process. This could be done by adding a reference counter for the socket file descriptors.

 * :unamused: `CLONE_FILES`

   We have **two** registries, but one **shared** file descriptor table. One way to deal with this could be a `mmap`ed file descriptor that could be used to communicate between the two registries.

   However: How would one indicate presence of the other?

 * :scream: `0`

   Again, **two** registries, but also a **copy** of the file descriptor table.

   At first glance this might be an obvious case of "we don't need to handle it", but consider the scenario mentioned in an earlier comment:

   Process 1 creates a socket, `clone`s into process 2, process 2 closes the socket... now what? Process 1 still has to be able to do operations on the socket, but it's essentially blackholed. We could use `memfd_create` in conjunction with `mmap`, we could even inspect `procfs`, but all of that will make it a nightmare to port to other systems.

Of course, one way to get there would be to wrap the corresponding syscalls and do some kind of IPC between the main process and various subprocesses, eg. via POSIX shared memory objects. This however is a little bit to complicated and I'd like to avoid wrapping additional libc calls as much as possible.

Another less error prone way in terms of moving parts that could go south would be to store *all* state that we have inside a shared mapping that is bound to a file descriptor. Again `memfd_create` comes to mind, but is there a more portable way?

Also, is this even feasible or are there other occasions than `CLONE_FILES` that have an impact here?

What about (`M`)`FD_CLOEXEC`? If either *none* or *all* the sockets in the registry are using `FD_CLOEXEC` and we're essentially setting `MFD_CLOEXEC` **IFF** all the sockets have `FD_CLOEXEC`, everything is fine. But if this is not the case, how do we handle this?
