### PR TITLE
Fix header includes.

### DIFF
--- a/src/blackhole.cc
+++ b/src/blackhole.cc
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: LGPL-3.0-only
+#include <unistd.h>
+#include <sys/stat.h>
+#include <errno.h>
 #include <cstring>
 #include <climits>
-#include <unistd.h>
-
-#include <sys/stat.h>
+#include <cstdlib>
+#include <initializer_list>
+#include <string>
 
 #include "blackhole.hh"
 #include "logging.hh"

--- a/src/dynports/dynports.cc
+++ b/src/dynports/dynports.cc
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
+#include <array>
 #include <stdexcept>
 #include <sys/types.h>
 #include <unistd.h>

--- a/src/globpath.cc
+++ b/src/globpath.cc
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-#include "globpath.hh"
-
+#include <stddef.h>
 #include <optional>
+#include <string>
+#include <string_view>
+
+#include "globpath.hh"
 
 enum class MatchResult {
     Matched,

--- a/src/ip2unix.cc
+++ b/src/ip2unix.cc
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: LGPL-3.0-only
+#include <getopt.h>
+#include <unistd.h>
+#include <dlfcn.h>
+#include <errno.h>
 #include <algorithm>
-#include <climits>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <fstream>
-#include <getopt.h>
 #include <string>
-#include <unistd.h>
-#include <dlfcn.h>
+#include <cctype>
+#include <fstream>
+#include <optional>
+#include <vector>
 
 #include "rules.hh"
 #include "serial.hh"

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-#include <iostream>
-
 #include <unistd.h>
 #include <sys/stat.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <iostream>
 
 #include "logging.hh"
 

--- a/src/logging.hh
+++ b/src/logging.hh
@@ -4,6 +4,7 @@
 
 #include <optional>
 #include <sstream>
+#include <string_view>
 
 /* A small helper so that we always get the basename of the file at compile
  * time instead of determining it at runtime.

--- a/src/preload.cc
+++ b/src/preload.cc
@@ -1,14 +1,19 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-#include <queue>
-#include <unordered_map>
-#include <variant>
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
 #include <memory>
 #include <mutex>
-
-#include <arpa/inet.h>
-#include <fcntl.h>
-#include <netinet/in.h>
-#include <sys/un.h>
+#include <functional>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 #ifndef WRAP_SYM
 #define WRAP_SYM(x) ip2unix_wrap_##x
@@ -22,6 +27,7 @@
 #include "socket.hh"
 #include "logging.hh"
 #include "serial.hh"
+#include "sockaddr.hh"
 
 #ifdef SYSTEMD_SUPPORT
 #include "systemd.hh"

--- a/src/realcalls.cc
+++ b/src/realcalls.cc
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 #define IP2UNIX_REALCALL_EXTERN
+#include <initializer_list>
+#include <memory>
+#include <mutex>
+
 #include "realcalls.hh"
 
 std::mutex g_dlsym_mutex;

--- a/src/realcalls.hh
+++ b/src/realcalls.hh
@@ -2,11 +2,13 @@
 #ifndef IP2UNIX_REALCALLS_HH
 #define IP2UNIX_REALCALLS_HH
 
-#include <cstring>
-#include <mutex>
-
 #include <unistd.h>
 #include <dlfcn.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <cstring>
+#include <mutex>
 
 #include "logging.hh"
 

--- a/src/rng.cc
+++ b/src/rng.cc
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-#include <chrono>
-
-#include <sys/types.h>
 #include <unistd.h>
+#include <stdint.h>
+#include <chrono>
 
 #include "rng.hh"
 

--- a/src/rng.hh
+++ b/src/rng.hh
@@ -3,6 +3,7 @@
 #define IP2UNIX_RANDOMIZER_HH
 
 #include <random>
+#include <algorithm>
 
 extern std::default_random_engine __generator;
 

--- a/src/rules/parse.cc
+++ b/src/rules/parse.cc
@@ -1,19 +1,21 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-#include <algorithm>
-#include <iostream>
-#include <fstream>
-#include <memory>
-#include <sstream>
-#include <unordered_map>
-
 #include <arpa/inet.h>
 #include <unistd.h>
-
+#include <ctype.h>
+#include <netinet/in.h>
+#include <stdint.h>
+#include <sys/socket.h>
 #include <yaml-cpp/yaml.h>
+#include <algorithm>
+#include <iostream>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <vector>
 
 #include "../rules.hh"
-
 #include "errno_list.hh"
+#include "types.hh"
 
 static const std::string describe_nodetype(const YAML::Node &node)
 {

--- a/src/serial.cc
+++ b/src/serial.cc
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 #include "serial.hh"
+#include "rules.hh"
+#include "systemd.hh"
+#include "types.hh"
 
 void serialise(const std::string &str, std::ostream &out)
 {

--- a/src/serial.hh
+++ b/src/serial.hh
@@ -2,11 +2,24 @@
 #ifndef IP2UNIX_SERIAL_HH
 #define IP2UNIX_SERIAL_HH
 
+#include <stdio.h>
 #include <deque>
 #include <sstream>
 #include <unordered_map>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 #include "rules.hh"
+
+enum class RuleDir;
+enum class SocketType;
+namespace Systemd {
+struct FdInfo;
+}  // namespace Systemd
+struct Rule;
 
 #ifdef SYSTEMD_SUPPORT
 #include "systemd.hh"

--- a/src/sockaddr.cc
+++ b/src/sockaddr.cc
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: LGPL-3.0-only
+#include <arpa/inet.h>
+#include <netinet/in.h>
 #include <cstring>
-#include <stdexcept>
 #include <optional>
 #include <sstream>
-
-#include <arpa/inet.h>
+#include <algorithm>
+#include <iterator>
 
 #include "sockaddr.hh"
 #include "rng.hh"

--- a/src/sockaddr.hh
+++ b/src/sockaddr.hh
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 #ifndef IP2UNIX_SOCKETADDR_HH
 #define IP2UNIX_SOCKETADDR_HH
+#include <netinet/in.h>
+#include <sys/un.h>
+#include <stdint.h>
+#include <sys/socket.h>
 #include <optional>
 #include <string>
 #include <variant>
+#include <cstddef>
+#include <utility>
 
-#include <netinet/in.h>
-#include <sys/un.h>
+struct sockaddr_in6;
+struct sockaddr_in;
 
 struct SockAddr : public sockaddr_storage
 {

--- a/src/sockaddr.hh
+++ b/src/sockaddr.hh
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 #ifndef IP2UNIX_SOCKETADDR_HH
 #define IP2UNIX_SOCKETADDR_HH
+#include <optional>
+#include <string>
 #include <variant>
 
 #include <netinet/in.h>

--- a/src/socket.cc
+++ b/src/socket.cc
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: LGPL-3.0-only
+#include <errno.h>
+#include <stdint.h>
+#include <unistd.h>
 #include <cstring>
-#include <fcntl.h>
-#include <arpa/inet.h>
-#include <sys/un.h>
+#include <string>
+#include <type_traits>
+#include <utility>
 
 #include "socket.hh"
 #include "realcalls.hh"
 #include "logging.hh"
+#include "blackhole.hh"
+#include "types.hh"
 
 std::optional<Socket::Ptr> Socket::find(int fd)
 {

--- a/src/socket.hh
+++ b/src/socket.hh
@@ -2,18 +2,23 @@
 #ifndef IP2UNIX_SOCKET_HH
 #define IP2UNIX_SOCKET_HH
 
+#include <sys/socket.h>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <queue>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "types.hh"
 #include "sockaddr.hh"
 #include "sockopts.hh"
 #include "dynports.hh"
 #include "blackhole.hh"
+
+enum class SocketType;
+struct BlackHole;
 
 struct Socket : std::enable_shared_from_this<Socket>
 {

--- a/src/sockopts.cc
+++ b/src/sockopts.cc
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-#include <cstdio>
-#include <cstring>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <asm/sockios.h>
+#include <errno.h>
+#include <cstdio>
+#include <cstring>
 
 #include "realcalls.hh"
 #include "sockopts.hh"

--- a/src/sockopts.hh
+++ b/src/sockopts.hh
@@ -2,10 +2,13 @@
 #ifndef IP2UNIX_SOCKOPT_HH
 #define IP2UNIX_SOCKOPT_HH
 
+#include <arpa/inet.h>
+#include <stdint.h>
+#include <sys/socket.h>
 #include <queue>
 #include <variant>
-
-#include <arpa/inet.h>
+#include <optional>
+#include <vector>
 
 #ifdef HAS_EPOLL
 #include <sys/epoll.h>

--- a/src/systemd.cc
+++ b/src/systemd.cc
@@ -1,16 +1,20 @@
 // SPDX-License-Identifier: LGPL-3.0-only
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/socket.h>
 #include <cstring>
 #include <unordered_map>
 #include <unordered_set>
 #include <deque>
-
-#include <fcntl.h>
+#include <algorithm>
+#include <cstdlib>
+#include <string>
+#include <utility>
 
 #include "rules.hh"
 #include "systemd.hh"
 #include "logging.hh"
 #include "serial.hh"
-#include "systemd.hh"
 
 #define SD_LISTEN_FDS_START 3
 

--- a/src/systemd.hh
+++ b/src/systemd.hh
@@ -2,7 +2,13 @@
 #ifndef IP2UNIX_SYSTEMD_HH
 #define IP2UNIX_SYSTEMD_HH
 
+#include <stddef.h>
+#include <optional>
+#include <vector>
+
 #include "rules.hh"
+
+struct Rule;
 
 namespace Systemd {
     struct FdInfo {

--- a/tests/helpers/accept_no_peer_addr.cc
+++ b/tests/helpers/accept_no_peer_addr.cc
@@ -1,10 +1,9 @@
-#include <cstdio>
-#include <cstdlib>
-
 #include <unistd.h>
-#include <sys/types.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
+#include <cstdio>
+#include <cstdlib>
 
 int main(void)
 {

--- a/tests/unit/dynports.cc
+++ b/tests/unit/dynports.cc
@@ -1,5 +1,7 @@
+#include <stdint.h>
 #include <string>
 #include <stdexcept>
+#include <unordered_set>
 
 #include "dynports.hh"
 

--- a/tests/unit/globpath.cc
+++ b/tests/unit/globpath.cc
@@ -1,4 +1,5 @@
 #include <stdexcept>
+#include <memory>
 
 #include "globpath.hh"
 

--- a/tests/unit/serial.cc
+++ b/tests/unit/serial.cc
@@ -1,4 +1,9 @@
 #include <serial.hh>
+#include <stdint.h>
+#include <stdexcept>
+
+#include "rules.hh"
+#include "types.hh"
 
 /* All the combinations of values we want to check */
 


### PR DESCRIPTION
In https://github.com/nixcloud/ip2unix/issues/31 it was suggested that cleaning up the imports was something worth doing.

This includes the fixes for #30  and #31, and I __think__ cleans up other imports as well.

The changes come from running the [include-what-you-use](https://github.com/include-what-you-use/include-what-you-use) tools, and then manually editing changes that were suggested.

I do have nix dev-shell set up in my `import-fix-wip` branch. Using `include-what-you-use` as nix tool seems to be broken. The dev-shell is based on work on the branch by @Et73f that I found when reading https://github.com/NixOS/nixpkgs/issues/189753

The devShell isn't part of this CR